### PR TITLE
FIX: Map macosx to osx for ipython terminal gui toolkit

### DIFF
--- a/mpl_gui/_manage_backend.py
+++ b/mpl_gui/_manage_backend.py
@@ -166,6 +166,9 @@ def select_gui_toolkit(newbackend=None):
         # if so are we in an IPython session
         ip = mod_ipython.get_ipython()
         if ip:
+            # macosx -> osx mapping for the osx backend in ipython
+            if required_framework == "macosx":
+                required_framework = "osx"
             ip.enable_gui(required_framework)
 
     # remember to set the global variable


### PR DESCRIPTION
Closes #5. There is a mapping in backend_bases: https://github.com/matplotlib/matplotlib/blob/62dfcfd32c9ac9e45cfa15bbcfd4c75aed8213cd/lib/matplotlib/backend_bases.py#L1635-L1661

Note that I tried to do a simple `lstrip("mac")`, but apparently required_framework can be None when inline is used, so that doesn't work.

The gui toolkit is called "osx" in ipython, so we need to map
the Matplotlib's "macosx" name over to that within an ipython
session.